### PR TITLE
Deal correctly wih the case that python-mpv is not installed

### DIFF
--- a/vidify/__init__.py
+++ b/vidify/__init__.py
@@ -6,6 +6,7 @@ logger, cross-platform variables...
 import sys
 from enum import Enum
 from typing import Optional
+from pkg_resources import DistributionNotFound, get_distribution
 
 
 class Platform(Enum):
@@ -31,6 +32,15 @@ elif sys.platform.find('bsd') != -1:
     CURRENT_PLATFORM = Platform.BSD
 else:
     CURRENT_PLATFORM = Platform.UNKNOWN
+
+
+def is_installed(*args: str) -> bool:
+    for pkgname in args:
+        try:
+            get_distribution(pkgname)
+        except DistributionNotFound:
+            return False
+    return True
 
 
 def format_name(artist: Optional[str], title: Optional[str]) -> str:

--- a/vidify/api/__init__.py
+++ b/vidify/api/__init__.py
@@ -10,7 +10,7 @@ import logging
 from enum import Enum
 from typing import Tuple, Optional
 
-from vidify import Platform
+from vidify import Platform, is_installed
 from vidify.gui import Res
 
 
@@ -24,8 +24,9 @@ class APIData(Enum):
     """
 
     def __new__(cls, short_name: str, description: str, icon: str,
-                platforms: Tuple[Platform], module: str, class_name: str,
-                connect_msg: Optional[str], gui_init_fn: Optional[str],
+                platforms: Tuple[Platform], installed: bool, module: str,
+                class_name: str, connect_msg: Optional[str],
+                gui_init_fn: Optional[str],
                 event_loop_interval: Optional[int]) -> object:
         obj = object.__new__(cls)
         # The short name displayed in the GUI, its description and the icon,
@@ -36,6 +37,7 @@ class APIData(Enum):
         # A tuple containing the supported platforms for this API. That way,
         # it's only shown in these.
         obj.platforms = platforms
+        obj.installed = installed
         # The module location and class name to import (for dependency
         # injection).
         obj.module = module
@@ -50,6 +52,7 @@ class APIData(Enum):
         "Any MPRIS compatible media player: Spotify, Rhythmbox...",
         Res.mpris_linux_icon,
         (Platform.LINUX, Platform.BSD),
+        is_installed('pydbus'),
         "vidify.api.mpris",
         "MPRISAPI",
         "Waiting for a song to play on any MPRIS player...",
@@ -60,6 +63,7 @@ class APIData(Enum):
         "The desktop Spotify client for Windows and MacOS.",
         Res.swspotify_icon,
         (Platform.WINDOWS, Platform.MACOS),
+        is_installed('swspotify'),
         "vidify.api.spotify.swspotify",
         "SwSpotifyAPI",
         "Waiting for a Spotify song to play...",
@@ -71,6 +75,7 @@ class APIData(Enum):
         " up.",
         Res.spotify_web_icon,
         tuple(Platform),  # Supports all platforms
+        is_installed('tekore'),
         "vidify.api.spotify.web",
         "SpotifyWebAPI",
         "Waiting for a Spotify song to play...",

--- a/vidify/player/__init__.py
+++ b/vidify/player/__init__.py
@@ -5,7 +5,9 @@ them.
 
 import importlib
 from enum import Enum
+from typing import Tuple
 
+from vidify import Platform, is_installed
 from vidify.gui import Res
 from vidify.config import Config
 from vidify.player.generic import PlayerBase
@@ -21,11 +23,16 @@ class PlayerData(Enum):
     """
 
     def __new__(cls, short_name: str, description: str, icon: str,
+                platforms: Tuple[Platform], installed: bool,
                 module: str, class_name: str, flags: list) -> object:
         obj = object.__new__(cls)
         obj.short_name = short_name
         obj.description = description
         obj.icon = icon
+        # A tuple containing the supported platforms for this Player. That way,
+        # it's only shown in these.
+        obj.platforms = platforms
+        obj.installed = installed
         # The module location to import, for dependency injection.
         obj.module = module
         # The player's class name inside its module.
@@ -39,6 +46,8 @@ class PlayerData(Enum):
         'VLC',
         'Widely used and very solid player.',
         Res.vlc_icon,
+        tuple(Platform),  # Supports all platforms
+        is_installed('python-vlc'),
         'vidify.player.vlc',
         'VLCPlayer',
         ('vlc_args',))
@@ -46,6 +55,8 @@ class PlayerData(Enum):
         'Mpv',
         'More lightweight and precise player than VLC.',
         Res.mpv_icon,
+        tuple(Platform),  # Supports all platforms
+        is_installed('python-mpv'),
         'vidify.player.mpv',
         'MpvPlayer',
         ('mpv_flags',))
@@ -53,6 +64,8 @@ class PlayerData(Enum):
         'External',
         'Play the videos on external devices.',
         Res.external_icon,
+        tuple(Platform),  # Supports all platforms
+        is_installed('zeroconf'),
         'vidify.player.external',
         'ExternalPlayer',
         ('api',))


### PR DESCRIPTION
Hi,

At the moment, if e.g. python-mpv is not installed it is still selectable in the menu. Selecting it an pressing continue (predictably) causes Vidify to crash. This PR checks if packages are installed, and if not, it sets the relevant API/player to unavailable (similar to how swspotify is unavailable on Linux).

I use the `is_installed` function that we used before in `setup.py`. I also went ahead and added the platform properties to the players, this makes it possible to (in the future maybe) have players which are platform specific.

I added the `is_installed` checks for all APIs and players (and not just python-mpv), this has three reasons:
1) It doesn't hurt. If for whatever reason one of them is not correctly installed even though it specified as dependency in setup.py. This will prevent Vidify from crashing in this case, the user would just see 'Unavailable" instead of a crash.
2) It is easier to implement this if I do it for all players/APIs instead of writing a special case for python-mpv, and it is also more future-proof this way.
3) Pip/setup.py might not be able to use `or` logic to set dependencies (e.g. python-vlc `or` python-mpv) but Gentoo's portage definitely can. Doing it like this allows me to utilize the full power of Gentoo's portage. Like this I don't have to have the ebuild hard depend on python-vlc/tekore etc. instead I can e.g. check if the user uses media-video/vlc and in that case pull in python-vlc (`DEPEND="vlc? ( dev-python/python-vlc )`). Or as another example: (`DEPEND="dbus? ( dev-python/pydbus )`), which would only pull in pydbus as a dependency if the user uses dbus. Handy for users who for whatever reason do not want to use dbus on their system, those can then pull in tekore as a dependency instead. This PR makes sure that vidify doesn't crash if some of these dependencies are missing, thus allowing my ebuild to utilize the full modularity of vidify.

I did some testing with this and it is producing the expected results for me. However, I'm not sure if I got `swspotify` right, this might or might not need capitalization (`SwSpotify`), but I'm not on windows so I can't test that.