### PR TITLE
Add note on corrupt YTDL cache to FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,9 @@ If the song doesn't have a metadata field with its title and artist (the latter 
 ### `FileNotFoundError: Could not find module 'libvlc.dll'.`
 Make sure that both Python and VLC are either 32 bits, or 64 bits, but not different. You should have a directory called `C:\Program Files (x86)\VideoLAN\VLC` (32b), or `C:\Program Files\VideoLAN\VLC` (64b).
 
+### Not playing any videos (`HTTP Error 403: Forbidden`)
+If Vidify is not playing any videos, and is throwing 403 Forbidden errors (with the `--debug` argument). The YouTube-DL cache has likely become corrupt or needs to be regenerated because of other reasons, please try deleting `~/.cache/youtube-dl`.
+
 ---
 
 ## Development


### PR DESCRIPTION
I've been having a bit of a problem with Vidify (or rather with YouTube-DL to be more precise).
I wasn't able to download any videos using YTDL, and as a consequence Vidify wasn't playing anything. Took me some time to figure out what was wrong, but I fixed it.

Turns out this is what happens if your YTDL cache becomes corrupt, luckily the solution is easy. I figured I'd add a note on this to the FAQ in case someone else loses power to their computer while Vidify is running and ends up with a corrupt YTDL cache.

It might still need windows/mac specific instructions. I suspect that for windows the cache will be somewhere in AppData, but as I am not on windows at the moment I'm not sure.

As a side thought, it might be possible to have Vidify automatically remove the YTDL cache in such cases with something like this:
```
try

except <403 Forbidden>
     if platform.startswith("Linux"):
             os.rmdir("~/.cache/youtube-dl")
     elif <windows specific instructions>
```

But I'm unsure what the side effects of deleting the cache are, so maybe it is not a good idea.