### PR TITLE
Fix CI, update python versions, fix dep on tekore

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-            python: [3.6, 3.7, 3.8]
+            python: ['3.8', '3.9', '3.10']
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -28,8 +28,11 @@ jobs:
               libmpv-dev \
               libnss3 \
               libpulse-dev \
+              libqt5gui5 \
               pulseaudio \
-              xvfb
+              xvfb \
+              vlc \
+              mpv
           python -m pip install -r dev/build_requires.txt
       - name: Run Tests
         run: sh dev/run-tests-docker.sh

--- a/dev/build_requires.txt
+++ b/dev/build_requires.txt
@@ -12,7 +12,7 @@ python-vlc
 qdarkstyle
 QtPy
 SwSpotify>=1.1.1; platform_system == "Windows" or platform_system == "Darwin"
-tekore < 2.0
+tekore
 vidify-audiosync == 0.2.*
 yt-dlp
 zeroconf

--- a/dev/run-tests-docker.sh
+++ b/dev/run-tests-docker.sh
@@ -4,7 +4,7 @@
 set -e
 
 export DISPLAY=:99
-Xvfb :99 -screen 0 640x480x8 -nolisten tcp &
+Xvfb ${DISPLAY} -screen 0 1280x1024x24 +extension RANDR -nolisten tcp &
 
 for binding in "PyQt5" "PySide2"; do
     echo ">> RUNNING TESTS FOR $binding"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ install_deps = [
     'dataclasses; python_version<"3.7"',
     # APIs and players
     'python-vlc',
-    'tekore==3.*',
+    'tekore',
     'zeroconf',
     'pydbus; platform_system=="Linux"',
     'SwSpotify>=1.1.1; platform_system=="Windows"'


### PR DESCRIPTION
Took quite some time, but CI works now :partying_face: 

Tests fail with tekore-2 which was specified in build_requires.txt.
Tekore-4 works, tekore-3 untested since that version has been removed from Gentoo.

Signed-off-by: Andrew Ammerlaan <andrewammerlaan@gentoo.org>