### PR TITLE
player/vlc.py: fix for python3.10

### DIFF
--- a/vidify/player/vlc.py
+++ b/vidify/player/vlc.py
@@ -75,9 +75,9 @@ class VLCPlayer(PlayerBase):
     def start_video(self, media: str, is_playing: bool = True) -> None:
         logging.info("Starting new video")
         if CURRENT_PLATFORM in (Platform.LINUX, Platform.BSD):
-            self._player.set_xwindow(self.winId())
+            self._player.set_xwindow(int(self.winId()))
         elif CURRENT_PLATFORM == Platform.WINDOWS:
-            self._player.set_hwnd(self.winId())
+            self._player.set_hwnd(int(self.winId()))
         elif CURRENT_PLATFORM == Platform.MACOS:
             self._player.set_nsobject(int(self.winId()))
 


### PR DESCRIPTION
Yesterday I switched the system python version to python 3.10 and sadly Vidify stopped working:

```
[15:06:12.054] INFO: Starting new video
Traceback (most recent call last):
File "/usr/lib/python3.10/site-packages/vidify/gui/window.py", line 398, in on_youtubedl_success
self.player.start_video(url, is_playing)
File "/usr/lib/python3.10/site-packages/vidify/player/vlc.py", line 78, in start_video
self._player.set_xwindow(self.winId())
File "/usr/lib/python3.10/site-packages/vlc.py", line 3643, in set_xwindow
return libvlc_media_player_set_xwindow(self, drawable)
File "/usr/lib/python3.10/site-packages/vlc.py", line 6493, in libvlc_media_player_set_xwindow
return f(p_mi, drawable)
ctypes.ArgumentError: argument 2: <class 'TypeError'>: wrong type
zsh: IOT instruction (core dumped)  vidify --debug
```

This small patch fixes the issue, I'm not sure if it is required on Windows as well, but it can't hurt to explicitly make things an integer.

Signed-off-by: Andrew Ammerlaan <andrewammerlaan@gentoo.org>